### PR TITLE
make blocksource trait async

### DIFF
--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -30,7 +30,7 @@ subtle = "2.2.3"
 time = "0.3"
 zcash_note_encryption = { version = "0.0", path = "../components/zcash_note_encryption" }
 zcash_primitives = { version = "0.5", path = "../zcash_primitives" }
-async-trait = "0.1.0"
+async-trait = "0.1.52"
 futures = "0.3"
 
 [build-dependencies]

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -30,7 +30,7 @@ subtle = "2.2.3"
 time = "0.3"
 zcash_note_encryption = { version = "0.0", path = "../components/zcash_note_encryption" }
 zcash_primitives = { version = "0.5", path = "../zcash_primitives" }
-async-trait = "0.1.68"
+async-trait = "0.1.0"
 
 [build-dependencies]
 protobuf-codegen-pure = "2.20"

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -31,7 +31,7 @@ time = "0.3"
 zcash_note_encryption = { version = "0.0", path = "../components/zcash_note_encryption" }
 zcash_primitives = { version = "0.5", path = "../zcash_primitives" }
 async-trait = "0.1.0"
-futures = "0.3.28"
+futures = "0.3"
 
 [build-dependencies]
 protobuf-codegen-pure = "2.20"

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -13,11 +13,13 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
+async-trait = "0.1.52"
 bech32 = "0.9.1"
 bls12_381 = "0.3.1"
 bs58 = { version = "0.4", features = ["check"] }
 base64 = "0.13"
 ff = "0.8"
+futures = "0.3"
 group = "0.8"
 hex = "0.4"
 jubjub = "0.5.1"
@@ -30,8 +32,6 @@ subtle = "2.2.3"
 time = "0.3"
 zcash_note_encryption = { version = "0.0", path = "../components/zcash_note_encryption" }
 zcash_primitives = { version = "0.5", path = "../zcash_primitives" }
-async-trait = "0.1.0"
-futures = "0.3"
 
 [build-dependencies]
 protobuf-codegen-pure = "2.20"

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -30,7 +30,7 @@ subtle = "2.2.3"
 time = "0.3"
 zcash_note_encryption = { version = "0.0", path = "../components/zcash_note_encryption" }
 zcash_primitives = { version = "0.5", path = "../zcash_primitives" }
-async-trait = "0.1.68"
+async-trait = "0.1.0"
 futures = "0.3"
 
 [build-dependencies]

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -30,7 +30,7 @@ subtle = "2.2.3"
 time = "0.3"
 zcash_note_encryption = { version = "0.0", path = "../components/zcash_note_encryption" }
 zcash_primitives = { version = "0.5", path = "../zcash_primitives" }
-async-trait = "0.1.52"
+async-trait = "0.1.68"
 futures = "0.3"
 
 [build-dependencies]

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -31,6 +31,7 @@ time = "0.3"
 zcash_note_encryption = { version = "0.0", path = "../components/zcash_note_encryption" }
 zcash_primitives = { version = "0.5", path = "../zcash_primitives" }
 async-trait = "0.1.0"
+futures = "0.3.28"
 
 [build-dependencies]
 protobuf-codegen-pure = "2.20"
@@ -45,7 +46,6 @@ zcash_proofs = { version = "0.5", path = "../zcash_proofs" }
 
 [features]
 test-dependencies = ["proptest", "zcash_primitives/test-dependencies"]
-wasm-extra = []
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -30,7 +30,7 @@ subtle = "2.2.3"
 time = "0.3"
 zcash_note_encryption = { version = "0.0", path = "../components/zcash_note_encryption" }
 zcash_primitives = { version = "0.5", path = "../zcash_primitives" }
-futures = "0.3.28"
+async-trait = "0.1.68"
 
 [build-dependencies]
 protobuf-codegen-pure = "2.20"

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -30,6 +30,7 @@ subtle = "2.2.3"
 time = "0.3"
 zcash_note_encryption = { version = "0.0", path = "../components/zcash_note_encryption" }
 zcash_primitives = { version = "0.5", path = "../zcash_primitives" }
+futures = "0.3.28"
 
 [build-dependencies]
 protobuf-codegen-pure = "2.20"
@@ -44,6 +45,7 @@ zcash_proofs = { version = "0.5", path = "../zcash_proofs" }
 
 [features]
 test-dependencies = ["proptest", "zcash_primitives/test-dependencies"]
+wasm-extra = []
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -256,6 +256,8 @@ pub trait WalletWrite: WalletRead {
 pub trait BlockSource {
     type Error;
 
+    /// Scan the specified `limit` number of blocks from the blockchain, starting at
+    /// `from_height`, applying the provided callback to each block.
     async fn with_blocks<F>(
         &self,
         from_height: BlockHeight,

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -252,11 +252,25 @@ pub trait WalletWrite: WalletRead {
 
 /// This trait provides sequential access to raw blockchain data via a callback-oriented
 /// API.
+#[cfg(feature = "wasm-extra")]
+#[async_trait::async_trait]
 pub trait BlockSource {
     type Error;
 
-    /// Scan the specified `limit` number of blocks from the blockchain, starting at
-    /// `from_height`, applying the provided callback to each block.
+    async fn with_blocks<F>(
+        &self,
+        from_height: BlockHeight,
+        limit: Option<u32>,
+        with_row: F,
+    ) -> Result<(), Self::Error>
+    where
+        F: FnMut(CompactBlock) -> Result<(), Self::Error>;
+}
+
+#[cfg(not(feature = "wasm-extra"))]
+pub trait BlockSource {
+    type Error;
+
     fn with_blocks<F>(
         &self,
         from_height: BlockHeight,

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -252,12 +252,11 @@ pub trait WalletWrite: WalletRead {
 
 /// This trait provides sequential access to raw blockchain data via a callback-oriented
 /// API.
-#[cfg(feature = "wasm-extra")]
-#[async_trait::async_trait]
+#[cfg(not(feature = "wasm-extra"))]
 pub trait BlockSource {
     type Error;
 
-    async fn with_blocks<F>(
+    fn with_blocks<F>(
         &self,
         from_height: BlockHeight,
         limit: Option<u32>,
@@ -267,10 +266,22 @@ pub trait BlockSource {
         F: FnMut(CompactBlock) -> Result<(), Self::Error>;
 }
 
-#[cfg(not(feature = "wasm-extra"))]
+#[cfg(feature = "wasm-extra")]
+#[async_trait::async_trait]
 pub trait BlockSource {
     type Error;
 
+    #[cfg(feature = "wasm-extra")]
+    async fn with_blocks<F>(
+        &self,
+        from_height: BlockHeight,
+        limit: Option<u32>,
+        with_row: F,
+    ) -> Result<(), Self::Error>
+    where
+        F: FnMut(CompactBlock) -> Result<(), Self::Error>;
+
+    #[cfg(not(feature = "wasm-extra"))]
     fn with_blocks<F>(
         &self,
         from_height: BlockHeight,

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -292,7 +292,7 @@ pub mod testing {
 
     pub struct MockBlockSource {}
 
-    #[async_trait::async_trait]
+    #[async_trait::async_trait(?Send)]
     impl BlockSource for MockBlockSource {
         type Error = Error<u32>;
 
@@ -303,7 +303,7 @@ pub mod testing {
             _with_row: F,
         ) -> Result<(), Self::Error>
         where
-            F: FnMut(CompactBlock) -> Result<(), Self::Error> + Send,
+            F: FnMut(CompactBlock) -> Result<(), Self::Error>,
         {
             Ok(())
         }

--- a/zcash_client_backend/src/data_api/chain.rs
+++ b/zcash_client_backend/src/data_api/chain.rs
@@ -158,6 +158,7 @@ where
 
     let mut prev_height = from_height;
     let mut prev_hash: Option<BlockHash> = validate_from.map(|(_, hash)| hash);
+
     let mut with_row = move |block: CompactBlock| {
         let current_height = block.height();
         let result = if current_height != prev_height + 1 {
@@ -177,7 +178,6 @@ where
         prev_hash = Some(block.hash());
         result.map_err(E::from)
     };
-
     block_on(cache.with_blocks(from_height, None, move |block| with_row(block)))
 }
 
@@ -283,7 +283,7 @@ where
 
     let data_clone = data.clone();
     let mut with_row = move |block: CompactBlock| {
-        let mut data_clone = data_clone.lock().unwrap();
+        let mut data_lock = data_clone.lock().unwrap();
         let current_height = block.height();
 
         // Scanned blocks MUST be height-sequential.
@@ -332,7 +332,7 @@ where
             }
         }
 
-        let new_witnesses = data_clone.advance_by_block(
+        let new_witnesses = data_lock.advance_by_block(
             &(PrunedBlock {
                 block_height: current_height,
                 block_hash,
@@ -359,7 +359,6 @@ where
 
         Ok(())
     };
-
     block_on(cache.with_blocks(last_height, limit, |block: CompactBlock| with_row(block)))?;
 
     Ok(())

--- a/zcash_client_backend/src/data_api/chain.rs
+++ b/zcash_client_backend/src/data_api/chain.rs
@@ -237,6 +237,7 @@ where
 /// # Ok(())
 /// # }
 /// ```
+#[cfg(not(feature = "wasm-extra"))]
 pub fn scan_cached_blocks<E, N, P, C, D>(
     params: &P,
     cache: &C,

--- a/zcash_client_backend/src/data_api/chain.rs
+++ b/zcash_client_backend/src/data_api/chain.rs
@@ -131,7 +131,6 @@ use crate::{
 /// - `Err(e)` if there was an error during validation unrelated to chain validity.
 ///
 /// This function does not mutate either of the databases.
-#[cfg(not(feature = "wasm-extra"))]
 pub fn validate_chain<N, E, P, C>(
     parameters: &P,
     cache: &C,
@@ -237,7 +236,6 @@ where
 /// # Ok(())
 /// # }
 /// ```
-#[cfg(not(feature = "wasm-extra"))]
 pub fn scan_cached_blocks<E, N, P, C, D>(
     params: &P,
     cache: &C,

--- a/zcash_client_backend/src/data_api/chain.rs
+++ b/zcash_client_backend/src/data_api/chain.rs
@@ -131,6 +131,7 @@ use crate::{
 /// - `Err(e)` if there was an error during validation unrelated to chain validity.
 ///
 /// This function does not mutate either of the databases.
+#[cfg(not(feature = "wasm-extra"))]
 pub fn validate_chain<N, E, P, C>(
     parameters: &P,
     cache: &C,

--- a/zcash_client_backend/src/lib.rs
+++ b/zcash_client_backend/src/lib.rs
@@ -8,22 +8,14 @@
 // Temporary until we have addressed all Result<T, ()> cases.
 #![allow(clippy::result_unit_err)]
 
-#[cfg(not(feature = "wasm-extra"))]
 pub mod address;
 pub mod data_api;
-#[cfg(not(feature = "wasm-extra"))]
 mod decrypt;
-#[cfg(not(feature = "wasm-extra"))]
 pub mod encoding;
-#[cfg(not(feature = "wasm-extra"))]
 pub mod keys;
-#[cfg(not(feature = "wasm-extra"))]
 pub mod proto;
-#[cfg(not(feature = "wasm-extra"))]
 pub mod wallet;
-#[cfg(not(feature = "wasm-extra"))]
 pub mod welding_rig;
-#[cfg(not(feature = "wasm-extra"))]
 pub mod zip321;
 
 pub use decrypt::{decrypt_transaction, DecryptedOutput};

--- a/zcash_client_backend/src/lib.rs
+++ b/zcash_client_backend/src/lib.rs
@@ -8,14 +8,22 @@
 // Temporary until we have addressed all Result<T, ()> cases.
 #![allow(clippy::result_unit_err)]
 
+#[cfg(not(feature = "wasm-extra"))]
 pub mod address;
 pub mod data_api;
+#[cfg(not(feature = "wasm-extra"))]
 mod decrypt;
+#[cfg(not(feature = "wasm-extra"))]
 pub mod encoding;
+#[cfg(not(feature = "wasm-extra"))]
 pub mod keys;
+#[cfg(not(feature = "wasm-extra"))]
 pub mod proto;
+#[cfg(not(feature = "wasm-extra"))]
 pub mod wallet;
+#[cfg(not(feature = "wasm-extra"))]
 pub mod welding_rig;
+#[cfg(not(feature = "wasm-extra"))]
 pub mod zip321;
 
 pub use decrypt::{decrypt_transaction, DecryptedOutput};

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -13,6 +13,7 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
+async-trait = "0.1.52"
 bech32 = "0.9.1"
 bs58 = { version = "0.4", features = ["check"] }
 ff = "0.8"
@@ -25,7 +26,6 @@ libsqlite3-sys= { version = "0.25.2", features = ["bundled"] }
 time = "0.3"
 zcash_client_backend = { version = "0.5", path = "../zcash_client_backend" }
 zcash_primitives = { version = "0.5", path = "../zcash_primitives" }
-async-trait = "0.1.68"
 
 [dev-dependencies]
 rand_core = "0.5.1"

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -25,6 +25,7 @@ libsqlite3-sys= { version = "0.25.2", features = ["bundled"] }
 time = "0.3"
 zcash_client_backend = { version = "0.5", path = "../zcash_client_backend" }
 zcash_primitives = { version = "0.5", path = "../zcash_primitives" }
+async-trait = "0.1.68"
 
 [dev-dependencies]
 rand_core = "0.5.1"

--- a/zcash_client_sqlite/src/chain.rs
+++ b/zcash_client_sqlite/src/chain.rs
@@ -66,6 +66,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
     use tempfile::NamedTempFile;
 
     use zcash_primitives::{
@@ -136,8 +137,8 @@ mod tests {
         .unwrap();
 
         // Scan the cache
-        let mut db_write = db_data.get_update_ops().unwrap();
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_write, None).unwrap();
+        let mut db_write = Arc::new(Mutex::new(db_data.get_update_ops().unwrap()));
+        scan_cached_blocks(tests::network(), &db_cache, db_write.clone(), None).unwrap();
 
         // Data-only chain should be valid
         validate_chain(
@@ -165,7 +166,7 @@ mod tests {
         .unwrap();
 
         // Scan the cache again
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_write, None).unwrap();
+        scan_cached_blocks(tests::network(), &db_cache, db_write, None).unwrap();
 
         // Data-only chain should be valid
         validate_chain(
@@ -208,8 +209,8 @@ mod tests {
         insert_into_cache(&db_cache, &cb2);
 
         // Scan the cache
-        let mut db_write = db_data.get_update_ops().unwrap();
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_write, None).unwrap();
+        let mut db_write = Arc::new(Mutex::new(db_data.get_update_ops().unwrap()));
+        scan_cached_blocks(tests::network(), &db_cache, db_write.clone(), None).unwrap();
 
         // Data-only chain should be valid
         validate_chain(
@@ -280,8 +281,8 @@ mod tests {
         insert_into_cache(&db_cache, &cb2);
 
         // Scan the cache
-        let mut db_write = db_data.get_update_ops().unwrap();
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_write, None).unwrap();
+        let mut db_write = Arc::new(Mutex::new(db_data.get_update_ops().unwrap()));
+        scan_cached_blocks(tests::network(), &db_cache, db_write, None).unwrap();
 
         // Data-only chain should be valid
         validate_chain(
@@ -354,8 +355,8 @@ mod tests {
         insert_into_cache(&db_cache, &cb2);
 
         // Scan the cache
-        let mut db_write = db_data.get_update_ops().unwrap();
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_write, None).unwrap();
+        let mut db_write = Arc::new(Mutex::new(db_data.get_update_ops().unwrap()));
+        scan_cached_blocks(tests::network(), &db_cache, db_write.clone(), None).unwrap();
 
         // Account balance should reflect both received notes
         assert_eq!(get_balance(&db_data, AccountId(0)).unwrap(), value + value2);
@@ -373,7 +374,7 @@ mod tests {
         assert_eq!(get_balance(&db_data, AccountId(0)).unwrap(), value);
 
         // Scan the cache again
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_write, None).unwrap();
+        scan_cached_blocks(tests::network(), &db_cache, db_write, None).unwrap();
 
         // Account balance should again reflect both received notes
         assert_eq!(get_balance(&db_data, AccountId(0)).unwrap(), value + value2);
@@ -403,8 +404,8 @@ mod tests {
             value,
         );
         insert_into_cache(&db_cache, &cb1);
-        let mut db_write = db_data.get_update_ops().unwrap();
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_write, None).unwrap();
+        let mut db_write = Arc::new(Mutex::new(db_data.get_update_ops().unwrap()));
+        scan_cached_blocks(tests::network(), &db_cache, db_write.clone(), None).unwrap();
         assert_eq!(get_balance(&db_data, AccountId(0)).unwrap(), value);
 
         // We cannot scan a block of height SAPLING_ACTIVATION_HEIGHT + 2 next
@@ -417,7 +418,7 @@ mod tests {
         let (cb3, _) =
             fake_compact_block(sapling_activation_height() + 2, cb2.hash(), extfvk, value);
         insert_into_cache(&db_cache, &cb3);
-        match scan_cached_blocks(&tests::network(), &db_cache, &mut db_write, None) {
+        match scan_cached_blocks(tests::network(), &db_cache, db_write.clone(), None) {
             Err(SqliteClientError::BackendError(e)) => {
                 assert_eq!(
                     e.to_string(),
@@ -433,7 +434,7 @@ mod tests {
 
         // If we add a block of height SAPLING_ACTIVATION_HEIGHT + 1, we can now scan both
         insert_into_cache(&db_cache, &cb2);
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_write, None).unwrap();
+        scan_cached_blocks(tests::network(), &db_cache, db_write, None).unwrap();
         assert_eq!(
             get_balance(&db_data, AccountId(0)).unwrap(),
             Amount::from_u64(150_000).unwrap()
@@ -469,8 +470,8 @@ mod tests {
         insert_into_cache(&db_cache, &cb);
 
         // Scan the cache
-        let mut db_write = db_data.get_update_ops().unwrap();
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_write, None).unwrap();
+        let mut db_write = Arc::new(Mutex::new(db_data.get_update_ops().unwrap()));
+        scan_cached_blocks(tests::network(), &db_cache, db_write.clone(), None).unwrap();
 
         // Account balance should reflect the received note
         assert_eq!(get_balance(&db_data, AccountId(0)).unwrap(), value);
@@ -482,7 +483,7 @@ mod tests {
         insert_into_cache(&db_cache, &cb2);
 
         // Scan the cache again
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_write, None).unwrap();
+        scan_cached_blocks(tests::network(), &db_cache, db_write, None).unwrap();
 
         // Account balance should reflect both received notes
         assert_eq!(get_balance(&db_data, AccountId(0)).unwrap(), value + value2);
@@ -517,8 +518,8 @@ mod tests {
         insert_into_cache(&db_cache, &cb);
 
         // Scan the cache
-        let mut db_write = db_data.get_update_ops().unwrap();
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_write, None).unwrap();
+        let mut db_write = Arc::new(Mutex::new(db_data.get_update_ops().unwrap()));
+        scan_cached_blocks(tests::network(), &db_cache, db_write.clone(), None).unwrap();
 
         // Account balance should reflect the received note
         assert_eq!(get_balance(&db_data, AccountId(0)).unwrap(), value);
@@ -540,7 +541,7 @@ mod tests {
         );
 
         // Scan the cache again
-        scan_cached_blocks(&tests::network(), &db_cache, &mut db_write, None).unwrap();
+        scan_cached_blocks(tests::network(), &db_cache, db_write, None).unwrap();
 
         // Account balance should equal the change
         assert_eq!(get_balance(&db_data, AccountId(0)).unwrap(), value - value2);

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -525,6 +525,9 @@ impl<'a, P: consensus::Parameters> WalletWrite for DataConnStmtCache<'a, P> {
 /// A wrapper for the SQLite connection to the block cache database.
 pub struct BlockDb(Connection);
 
+unsafe impl Send for BlockDb {}
+unsafe impl Sync for BlockDb {}
+
 impl BlockDb {
     /// Opens a connection to the wallet database stored at the specified path.
     pub fn for_path<P: AsRef<Path>>(path: P) -> Result<Self, rusqlite::Error> {
@@ -532,10 +535,11 @@ impl BlockDb {
     }
 }
 
+#[async_trait::async_trait(?Send)]
 impl BlockSource for BlockDb {
     type Error = SqliteClientError;
 
-    fn with_blocks<F>(
+    async fn with_blocks<F>(
         &self,
         from_height: BlockHeight,
         limit: Option<u32>,


### PR DESCRIPTION
In order to make the `BlockSource` trait compatible with `wasm`, it needed to be converted to an async trait. This requirement was identified while working in this PR: https://github.com/KomodoPlatform/atomicDEX-API/blob/4187ca90343d45d59343b77e7cab3781e90f6fc9/mm2src/coins/z_coin/storage/blockdb/blockdb_idb_storage.rs#L309-L318 . by doing this, the trait is able to be used effectively in `wasm`.

To ensure thread safety and enable the use of `BlockSource` in asynchronously manner, I modified both the `BlockSource` trait and the `scan_cached_blocks` function. Changes included allowing the `scan_cached_blocks` function to accept an `Arc<Mutex<D>>` parameter, which provided the necessary thread safety guarantees.