### PR TITLE
fix unconfirmed change note tracking in transactions

### DIFF
--- a/zcash_extras/src/wallet.rs
+++ b/zcash_extras/src/wallet.rs
@@ -2,12 +2,13 @@
 use std::fmt::{Debug, Display};
 
 use zcash_primitives::{
-    consensus::{self, BranchId},
+    consensus::{self, BranchId, NetworkUpgrade},
     memo::MemoBytes,
     sapling::prover::TxProver,
     transaction::{
         builder::Builder,
         components::{amount::DEFAULT_FEE, Amount},
+        Transaction,
     },
     zip32::{ExtendedFullViewingKey, ExtendedSpendingKey},
 };
@@ -15,9 +16,47 @@ use zcash_primitives::{
 use crate::WalletWrite;
 use zcash_client_backend::{
     address::RecipientAddress,
-    data_api::{error::Error, SentTransaction},
+    data_api::{error::Error, ReceivedTransaction, SentTransaction},
+    decrypt_transaction,
     wallet::{AccountId, OvkPolicy},
 };
+
+/// Scans a [`Transaction`] for any information that can be decrypted by the accounts in
+/// the wallet, and saves it to the wallet.
+pub async fn decrypt_and_store_transaction<N, E, P, D>(
+    params: &P,
+    data: &mut D,
+    tx: &Transaction,
+) -> Result<(), E>
+where
+    E: From<Error<N>>,
+    P: consensus::Parameters,
+    D: WalletWrite<Error = E>,
+{
+    // Fetch the ExtendedFullViewingKeys we are tracking
+    let extfvks = data.get_extended_full_viewing_keys().await?;
+
+    let max_height = data.block_height_extrema().await?.map(|(_, max)| max + 1);
+    let height = data
+        .get_tx_height(tx.txid())
+        .await?
+        .or(max_height)
+        .or_else(|| params.activation_height(NetworkUpgrade::Sapling))
+        .ok_or(Error::SaplingNotActive)?;
+
+    let outputs = decrypt_transaction(params, height, tx, &extfvks);
+    if outputs.is_empty() {
+        Ok(())
+    } else {
+        data.store_received_tx(&ReceivedTransaction {
+            tx,
+            outputs: &outputs,
+        })
+        .await?;
+
+        Ok(())
+    }
+}
 
 #[allow(clippy::needless_doctest_main)]
 /// Creates a transaction paying the specified address from the given account.
@@ -182,8 +221,7 @@ where
         RecipientAddress::Shielded(to) => {
             builder.add_sapling_output(ovk, to.clone(), value, memo.clone())
         }
-
-        RecipientAddress::Transparent(to) => builder.add_transparent_output(&to, value),
+        RecipientAddress::Transparent(to) => builder.add_transparent_output(to, value),
     }
     .map_err(Error::Builder)?;
 
@@ -208,6 +246,11 @@ where
                 .expect("we sent to this address")
         }
     };
+
+    // Automatically decrypt and store any outputs sent to our wallet, including change.
+    // This uses our viewing keys to find any outputs we can decrypt, creates decrypted
+    // note data for spendability, and saves them to the wallet database.
+    decrypt_and_store_transaction(params, wallet_db, &tx).await?;
 
     wallet_db
         .store_sent_tx(&SentTransaction {

--- a/zcash_extras/src/wallet.rs
+++ b/zcash_extras/src/wallet.rs
@@ -36,13 +36,15 @@ where
     // Fetch the ExtendedFullViewingKeys we are tracking
     let extfvks = data.get_extended_full_viewing_keys().await?;
 
-    let max_height = data.block_height_extrema().await?.map(|(_, max)| max + 1);
+    let max_height = data
+        .block_height_extrema()
+        .await?
+        .map(|(_, max)| max + 1)
+        .ok_or(Error::ScanRequired)?;
     let height = data
         .get_tx_height(tx.txid())
         .await?
-        .or(max_height)
-        .or_else(|| params.activation_height(NetworkUpgrade::Sapling))
-        .ok_or(Error::SaplingNotActive)?;
+        .unwrap_or_else(|| max_height);
 
     let outputs = decrypt_transaction(params, height, tx, &extfvks);
     if outputs.is_empty() {

--- a/zcash_extras/src/wallet.rs
+++ b/zcash_extras/src/wallet.rs
@@ -2,7 +2,7 @@
 use std::fmt::{Debug, Display};
 
 use zcash_primitives::{
-    consensus::{self, BranchId, NetworkUpgrade},
+    consensus::{self, BranchId},
     memo::MemoBytes,
     sapling::prover::TxProver,
     transaction::{
@@ -41,10 +41,7 @@ where
         .await?
         .map(|(_, max)| max + 1)
         .ok_or(Error::ScanRequired)?;
-    let height = data
-        .get_tx_height(tx.txid())
-        .await?
-        .unwrap_or_else(|| max_height);
+    let height = data.get_tx_height(tx.txid()).await?.unwrap_or(max_height);
 
     let outputs = decrypt_transaction(params, height, tx, &extfvks);
     if outputs.is_empty() {

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -634,6 +634,7 @@ impl<'a, P: consensus::Parameters, R: RngCore> Builder<'a, P, R> {
         // Change output
         //
 
+        /*
         if change.is_positive() {
             // Send change to the specified change address. If no change address
             // was set, send change to the first Sapling address given as input.
@@ -654,6 +655,7 @@ impl<'a, P: consensus::Parameters, R: RngCore> Builder<'a, P, R> {
 
             self.add_sapling_output(Some(change_address.0), change_address.1, change, None)?;
         }
+        */
 
         //
         // Record initial positions of spends and outputs

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -634,7 +634,6 @@ impl<'a, P: consensus::Parameters, R: RngCore> Builder<'a, P, R> {
         // Change output
         //
 
-        /*
         if change.is_positive() {
             // Send change to the specified change address. If no change address
             // was set, send change to the first Sapling address given as input.
@@ -655,7 +654,6 @@ impl<'a, P: consensus::Parameters, R: RngCore> Builder<'a, P, R> {
 
             self.add_sapling_output(Some(change_address.0), change_address.1, change, None)?;
         }
-        */
 
         //
         // Record initial positions of spends and outputs


### PR DESCRIPTION
This fixes the issue where change outputs weren't being tracked properly in the unconfirmed state, which could cause incorrect balance calculations and note availability issues https://github.com/KomodoPlatform/komodo-defi-framework/issues/2273